### PR TITLE
Update es.js

### DIFF
--- a/locales/es.js
+++ b/locales/es.js
@@ -6,11 +6,11 @@ no:
 print:
 "Imprimir",
 download_as_pdf:
-"Descarga como PDF",
+"Descargar como PDF",
 checkout:
-"Checkout",
+"Realizar pedido",
 close:
-"Cierra",
+"Cerrar",
 name:
 "Nombre y Apellidos",
 company_name:
@@ -46,23 +46,23 @@ finalize:
 country:
 "País",
 subtotal:
-"Subtotal IVA inc",
+"Subtotal",
 rebate:
 "Descuento",
 apply_promo_code:
 "Aplicar código de promoción",
 my_cart:
-"Tu carrito",
+"Carrito",
 my_cart_content:
-"Contenido de mi carrito",
+"Contenido del carrito",
 shipping_method:
-"Método del envío",
+"Método de envío",
 payment_method:
 "Método de pago",
 confirm_order:
 "Confirme la orden",
 bill_me_later:
-"Factúrame más tarde",
+"Facturar más tarde",
 bill_me_later_explanation:
 "La factura se enviará por correo electrónico.",
 promo_code_applied_successfully:
@@ -70,7 +70,7 @@ promo_code_applied_successfully:
 promo_code_is_invalid:
 "El código promocional es válido.",
 promo_code_code:
-"¿Tienes un descuento?",
+"¿Tiene un descuento?",
 promo_code_rate_on_order:
 "descuento en la orden",
 promo_code_alternate_price:
@@ -142,25 +142,25 @@ login_form_login_action:
 login_form_forgot_password_action:
 "He olvidado mi contraseña",
 forgot_password_forgot_your_password:
-"¿Olvidaste tu contraseña?",
+"¿Olvidó su contraseña?",
 forgot_password_please_enter_email:
-"Ingresa tu email, te enviaremos un correo electrónico con un enlace único para restablecer tu contraseña.",
+"Indíque su email, le enviaremos un correo electrónico con un enlace para restablecer tu contraseña.",
 forgot_password_success_email_sent:
 "Correo electrónico enviado",
 forgot_password_email_sent_message:
-"Te hemos enviado un correo electrónico con las instrucciones sobre cómo restablecer la contraseña. Consulta el correo y sigues los pasos.",
+"Le hemos enviado un correo electrónico con las instrucciones para  restablecer la contraseña. Consulte el correo y sigua los pasos.",
 login_checkout_as_guest:
 "Pagar como invitado",
 login_checkout_as_guest_notice:
-"Al final del proceso de verificación se te ofrecerá la posibilidad de crear una cuenta utilizando la información que introdujo durante el proceso de pago.",
+"Al final del proceso de verificación se le ofrecerá la posibilidad de crear una cuenta utilizando la información que introdujo durante el proceso de pago.",
 shipping_address_same_as_billing:
-"Use esta dirección para la facturación",
+"Use esta dirección para el envío",
 shipping_method_method_name:
 "Método de envío",
 shipping_method_shipping_price:
-"Precio de envío",
+"Precio del envío",
 shipping_method_failure_message:
-"No hemos sido capaces de encontrar un método de envío posible. Por favor, asegúrese de que su dirección de envío es correcta y vuelva a intentarlo.",
+"No hemos sido capaces de encontrar un método de envío disponible. Por favor, asegúrese de que su dirección de envío es correcta y vuelva a intentarlo.",
 shipping_method_failure_click_here_to_edit:
 "Haga clic aquí para editar su dirección del envío",
 payment_method_card_holder:
@@ -170,7 +170,7 @@ payment_method_card_type:
 payment_method_card_number:
 "Número de tarjeta",
 payment_method_card_cvc:
-"CSC",
+"CVC",
 payment_method_card_exp_month:
 "Vencimiento Mes / Año",
 payment_method_card_exp_year:
@@ -180,23 +180,23 @@ payment_method_cvc_infos:
 create_an_account:
 "Crear una cuenta",
 why_create_account:
-"Para una comprobación más rápida en tu próximo pedido, simplemente introduces la contraseña e inicia la sesión.",
+"Para una comprobación más rápida en su próximo pedido, simplemente introduzca la contraseña e inicie la sesión.",
 reset_password:
 "Restablecer contraseña",
 reset_password_success:
-"Restablecer contraseña completado",
+"Contraseña restablecida con éxito",
 reset_password_changed:
-"Tu contraseña ha sido cambiada.",
+"Su contraseña ha sido cambiada.",
 reset_password_click_here_to_login:
 "Click aquí para iniciar sesión",
 thankyou_message:
-"Gracias por tu pedido! La factura ha sido enviada por correo electrónico, lo recibirá pronto. Muchas gracias y hasta la próxima compra!",
+"Gracias por su pedido. La factura ha sido enviada por correo electrónico. Muchas gracias por su compra.",
 thankyou_submessage:
-"Pronto recibirás un email de confirmación.",
+"Pronto recibirá un email de confirmación.",
 account_created_successfully:
 "Cuenta creada con éxito",
 account_created_successfully_message:
-"Tu cuenta ha sido creada correctamente, gracias.",
+"Su cuenta ha sido creada correctamente, gracias.",
 errors_required:
 "Este campo es obligatorio",
 errors_email_must_be_unique:
@@ -208,23 +208,23 @@ errors_email_must_be_valid:
 errors_email_does_not_match_any_existing_user:
 "No existe ningún usuario con este correo electrónico",
 errors_email_does_not_match_reset_password_request:
-"La email del usuario no coincide con ninguna solicitud de reajuste de contraseña.",
+"La dirección de email no coincide con ninguna solicitud de cambio de contraseña.",
 errors_reset_password_token_expired:
 "El tiempo para restablecer la contraseña ha caducado.",
 errors_invalid_authentication_infos:
-"Informaciones de autenticación no válidas",
+"Información de autenticación no válidas",
 error_payment_items_empty:
-"Parece que su orden es inválido, por favor, vuelva a cargar la página. Ningún importe ha sido debitado en su tarjeta.",
+"Parece que su pedido es incorrecto, por favor, vuelva a cargar la página. No hemos realizado ningún cargo.",
 error_payment_items_are_invalid:
-"No hemos podidos completar su orden. Parece que uno de los artículos en su carrito tiene un precio inválido.",
+"No hemos podido completar su pedido. Parece que uno de los artículos en su carrito tiene un precio incorrecto.",
 error_crawling_failed:
-"No hemos sido capaces de validar tu pedido, ningún importe ha sido debitado en su tarjeta, por favor intenta nuevamente en unos momentos.",
+"No hemos sido capaces de validar tu pedido, y no hemos realizado ningún cargo. Por favor, intentelo de nuevo en unos minutos.",
 powered_by:
 "Powered and secured by",
 promocode_rate_format:
-"{0}% de descuento en tu pedido",
+"{0}% de descuento en su pedido",
 promocode_amount_format:
-"{0} de descuento en tu pedido",
+"{0} de descuento en su pedido",
 shipping_method_business_days:
 "{0} días laborales",
 shipping_method_business_day:
@@ -240,43 +240,43 @@ order_infos:
 generic_error_title:
 "Oops, hubo un error.",
 promocode_deleted_at_checkout:
-"El descuento que utilizas ha alcanzado su límite de uso mientras estabas haciendo tu pedido. Disculpas las molestias.",
+"El descuento que utiliza ha alcanzado su límite de uso mientras estaba haciendo su pedido. Disculpe las molestias.",
 continue_shopping:
-"Continuar las compras",
+"Continuar comprando",
 payment_required_message:
 "El carrito ha sido desactivada para esta web. Si eres el administrador, por favor accede a Snipcart y resuelve el problema.",
 payment_require_title:
 "El carrito está desactivado.",
 configuration_problem:
-"Problema en la configuración ",
+"Problema en la configuración.",
 additionnal_information:
 "Introduzca un mensaje abajo si desea enviar comentarios o más información sobre este problema.",
 send_error:
-"Enviar este error al propietario del sitio web",
+"Enviar este error al propietario del sitio web.",
 message_sent:
 "Mensaje enviado, gracias",
 paypalexpress_loading:
-"Será redirigido a Paypal para hacer el pago pronto.",
+"Será redirigido a Paypal para hacer el pago.",
 paypalexpress_cancelled:
-"Transacción cancelada. Puede hacer clic en el botón de abajo para intentarlo de nuevo o simplemente seguir en la tienda.",
+"Transacción cancelada. Puede hacer clic en el botón de abajo para intentarlo de nuevo o volver en la tienda.",
 retry:
-"Vuelves a intentarlo",
+"Vuelva a intentarlo",
 error_crawlingfailed_title:
-"Algo salió mal en la validación de tu pedido, no te preocupes, ningún importe ha sido debitado.",
+"Algo salió mal en la validación de su pedido, no se preocupe, no se ha cobrado ningún importe.",
 error_crawling_unreachable:
-"Artículo <strong>{0}</strong> no está disponible en <strong>{1}</strong>. Asegúrese de que la URL del producto está disponible.",
+"Artículo <strong>{0}</strong> no disponible en <strong>{1}</strong>. Asegúrese de que la URL del producto está disponible.",
 error_crawling_product_not_found:
-"Artículo <strong>{0}</strong> no está disponible en <strong>{1}</strong>.",
+"Artículo <strong>{0}</strong> no disponible en <strong>{1}</strong>.",
 error_crawling_price_not_found:
-"Artículo <strong>{0}</strong> no tiene ningún precio especificado en <strong>{1}</strong>, especificarlo con data-item-price.",
+"El artículo <strong>{0}</strong> no tiene ningún precio especificado en <strong>{1}</strong>, especificarlo con data-item-price.",
 error_crawling_price_doesnot_match:
-"Artículo <strong>{0}</strong> price at <strong>{3}</strong> is <strong>{2}</strong> but should be <strong>{1}</strong>.",
+"El precio del artículo <strong>{0}</strong> en <strong>{3}</strong> es <strong>{2}</strong> pero debería ser <strong>{1}</strong>.",
 error_crawlingfailed_title_test:
-"Algo salió mal cuando validabamos el pedido, no te preocupes, tu tarjeta no ha sido cargada. Esta página esta en Test mode.",
+"Algo salió mal cuando validabamos su pedido, no se preocupes, su tarjeta no ha sido cargada. Esta página esta en Test mode.",
 order_completedon:
 "Colocado en",
 payment_method_status:
-"Estado de transacción",
+"Estado de la transacción",
 payment_method_status_approved:
 "Aprobado",
 order_reference_number:
@@ -288,11 +288,11 @@ order_invoice_number:
 order_authorization_code:
 "Código de autorización",
 item_is_being_added:
-"Añadiendo el artículo a la cesta...",
+"Añadiendo el artículo al carrito...",
 order_completing_payment:
 "Ejecutando pedido...",
 calculating_shipping_fees:
-"Consiguiendo tarifas de envío...",
+"Calculando tarifas de envío...",
 saving:
 "Guardando...",
 loading:


### PR DESCRIPTION
En unos lugares se trata "de tu" y en otros "de usted", se ha unificado todo al tratamiento "de usted", que es más formal en español.
En ocasiones se habla de "Pedido" y en otras de "Orden", se ha unificado todo a "Pedido". Estos son los cambios realizados:

{download_as_pdf} falta una "r".
{checkout} estaba sin traducir.
[close] mejor decir "Cerrar" en impresonal, "Cierra" es impreativo.
{subtotal} el IVA sobra en este contexto, puede ser que no se aplique.
{my_cart} y {my_cart_content} mejor sin especificar posesión.
{shipping_method} sobra una "l" es "de", no "del".
{bill_me_later} mejor sin especificar posesión.
{promo_code_code}, {forgot_password_forgot_your_password}, [forgot_password_please_enter_email], [forgot_password_email_sent_message], [login_checkout_as_guest_notice], {reset_password_changed}, {thankyou_submessage}, {account_created_successfully_message}, {promocode_deleted_at_checkout}: mejor tratamiento "de usted".
[shipping_address_same_as_billing] mal traducido, debe decir "Use esta dirección para el envío".
{shipping_method_shipping_price} falta una "l", es "del", no "de".
{shipping_method_failure_message}, decir "posible" no es muy natural en ese contexto, mejor decir "disponible".
{thankyou_message} mejor tratamiento "de usted" y en un tono más formal.
{payment_method_card_cvc} es "CVC", no "CSC"
{reset_password_success}, {errors_email_does_not_match_reset_password_request}, {error_payment_items_empty}, {error_payment_items_are_invalid}, {continue_shopping}, {paypalexpress_cancelled}, {error_crawlingfailed_title}, {item_is_being_added}: malas traducciones, ya corregidas.
{paypalexpress_loading} sobra el "pronto".
{error_crawling_price_doesnot_match} estaba sin traducir.