### PR TITLE
Created localization files for Norwegian bokmaal ...

### DIFF
--- a/locales/nb-NO.js
+++ b/locales/nb-NO.js
@@ -1,0 +1,318 @@
+Snipcart.execute('registerLocale', 'nb-NO', {
+yes:
+"Ja",
+no:
+"Nei",
+print:
+"Print ut",
+download_as_pdf:
+"Last ned som PDF",
+checkout:
+"Til kassen",
+close:
+"Lukk",
+name:
+"Navn",
+company_name:
+"Firmanavn",
+share_by_email:
+"Del via Email",
+email:
+"E-mail",
+password:
+"Passord",
+confirm_password:
+"Bekreft passord",
+ok:
+"OK",
+send:
+"Send",
+address_1:
+"Adresse",
+address_2:
+"Adresse 2",
+city:
+"Poststed",
+postal_code:
+"Postnummer",
+phone:
+"Telefon nr.",
+previous:
+"Tilbake",
+next:
+"Neste",
+finalize:
+"Kjøp",
+country:
+"Land",
+subtotal:
+"Totalt",
+rebate:
+"Rabatt",
+apply_promo_code:
+"Rabattkode",
+my_cart:
+"Handlekurv",
+continue_shopping:
+"Fortsett å handle",
+my_cart_content:
+"Handlekurv",
+shipping_method:
+"Frakt",
+payment_method:
+"Bestill og betal",
+confirm_order:
+"BETAL OG FULLFØR",
+bill_me_later:
+"Betal senere",
+bill_me_later_explanation:
+"Du får en faktura tilsendt per email",
+promo_code_applied_successfully:
+"Rabattkode er godkjent.",
+promo_code_is_invalid:
+"Rabattkode er ugyldig.",
+promo_code_is_expired:
+"Rabattkode er ugyldig.",
+promo_code_code:
+"Har du en rabattkode?",
+promo_code_rate_on_order:
+"Rabatt",
+promo_code_alternate_price:
+"Ny pris",
+total:
+"Total",
+province_state:
+"Region",
+billing_address:
+"Betalingsadresse",
+shipping_address:
+"Leveringsadresse",
+payment_informations:
+"Betalingsinformasjon",
+payment_informations_bill_me_later:
+"Betal senere",
+payment_informations_paypalexpress:
+"Betal med Paypal",
+credit_card_type_mastercard:
+"Mastercard",
+credit_card_type_visa:
+"Visa",
+credit_card_type_amex:
+"American Express",
+months_january:
+"Januar",
+months_february:
+"Februar",
+months_march:
+"Mars",
+months_april:
+"April",
+months_may:
+"Mai",
+months_june:
+"Juni",
+months_july:
+"Juli",
+months_august:
+"August",
+months_september:
+"September",
+months_october:
+"Oktober",
+months_november:
+"November",
+months_december:
+"December",
+cart_items_table_item:
+"Varer",
+cart_items_table_description:
+"Beskrivelse",
+cart_items_table_quantity:
+"Antall",
+cart_items_table_unit_price:
+"Pris",
+cart_items_table_total_price:
+"Totalt",
+cart_empty_text:
+"Handlekurven er tom.",
+new_account_form_create_new_account:
+"Lag ny bruker",
+new_account_form_create_new_account_action:
+"Lag ny bruker",
+login_form_having_an_account:
+"Logg inn",
+login_form_login_action:
+"Logg inn",
+login_form_forgot_password_action:
+"Glemt passord",
+forgot_password_forgot_your_password:
+"Glemt passord?",
+forgot_password_please_enter_email:
+"Oppgi e-postadressen din i feltet under, så sender vi deg nytt passord.",
+forgot_password_success_email_sent:
+"Email er sendt",
+forgot_password_email_sent_message:
+"Du vil nå motta en mail med instrukser om hvordan du nullstiller passord ditt.",
+login_checkout_as_guest:
+"Bestill som gjest",
+login_checkout_as_guest_notice:
+"I slutten av betalingen, kan du velge å lage en bruker.",
+shipping_address_same_as_billing:
+"Bruk samme adresse til levering",
+shipping_method_method_name:
+"Leveringsmåte",
+shipping_method_shipping_price:
+"Fraktkostnad",
+shipping_method_failure_message:
+"Det var ikke muligt at finde den ønskede levereringsmetode. Venligst tjek om din adresse er rigtig og prøv igen",
+shipping_method_failure_click_here_to_edit:
+"Klikk her for å endre leveringsadresse",
+payment_method_card_holder:
+"Navn på kortholder",
+payment_method_card_type:
+"Korttype",
+payment_method_card_number:
+"Kortnummer",
+payment_method_card_cvc:
+"CVC",
+payment_method_card_exp_month:
+"Utløpsdato",
+payment_method_card_exp_year:
+"År",
+payment_method_cvc_infos:
+"For å gjøre din kredittkortbetaling så sikker som mulig, krever vi at du oppgir en sikkerhetskode fra ditt kredittkort. Denne koden er de tre siste sifferne av tallet som er trykket i signaturfeltet på baksiden av kredittkortet ditt. ",
+create_an_account:
+"Lag bruker",
+why_create_account:
+"Gjør det enklere å bestille neste gang, tast inn passord for å lage en konto.",
+reset_password:
+"Nullstill passord",
+reset_password_success:
+"Ditt passord er nå nullstilt",
+reset_password_changed:
+"Ditt passord er nå endret.",
+reset_password_click_here_to_login:
+"Klikk her for å logge inn",
+thankyou_message:
+"Takk for din bestilling. Du vil nå motta en Email med ordrebekreftelsen.",
+thankyou_submessage:
+"Du vil nå motta en ordrebekreftelse .",
+account_created_successfully:
+"Profil oprettet.",
+account_created_successfully_message:
+"Din profil er oprettet.",
+errors_required:
+"Må fylles ut",
+errors_email_must_be_unique:
+" Email adresse er allerede i bruk",
+errors_both_password_must_match:
+"Passordene stemmer ikke overens",
+errors_email_must_be_valid:
+"Tast inn en ekte Emailadresse.",
+errors_email_does_not_match_any_existing_user:
+"Det finnes ingen bruker med denne emailen",
+errors_email_does_not_match_reset_password_request:
+"Emailen stemmer ikke",
+errors_reset_password_token_expired:
+"Be om nytt passord igjen.",
+errors_invalid_authentication_infos:
+"Ugyldig identifikasjonsinformasjon",
+error_payment_items_empty:
+"Vi kan for øyeblikket ikke behandle bestillingen din. Vennligst oppdater siden og prøv igjen.",
+error_payment_items_are_invalid:
+"Det er ikke mulig å gjennomføre din bestilling. En av varerne har en ugyldig pris, vennligst kontakt kundeservice.",
+error_crawling_failed:
+"Det er ikke mulig å gjennomføre din bestilling. Vennligst kontakt kundeservice.",
+powered_by:
+"Powered and secured by",
+promocode_rate_format:
+"{0}% rabat på din ordre",
+promocode_amount_format:
+"{0} rabatt på din ordre",
+shipping_method_business_days:
+"{0} Virkedager",
+shipping_method_business_day:
+"{0} Virkedag",
+shipping_method_delivery_time:
+"Til {0}", // By 2013-11-28
+welcome:
+"Velkommen",
+back:
+"Tilbake",
+order_infos:
+"Ordreinformasjon",
+generic_error_title:
+"Oops, en feil oppstod.",
+promocode_deleted_at_checkout:
+"Din rabattkode er brukt opp.",
+continue_shopping:
+"Fortsett å handle",
+payment_required_message:
+"Betalingssystemet er ikke tilgjengelig på denne hjemmesiden. Logg inn på snipcart for å løse problemet",
+payment_require_title:
+"Betalingssystemet er deaktiveret.",
+configuration_problem:
+"Konfigurationsproblem",
+additionnal_information:
+"Skriv inn en beskjed, om vil sende feedback eller informasjon om dette problemet.",
+send_error:
+"Send denne meldingen til webmasteren",
+message_sent:
+"Takk for beskjeden",
+paypalexpress_loading:
+"Du blir nå omdirigert til paypal, for å gennemføre betalingen.",
+paypalexpress_cancelled:
+"ordren er annullert.",
+retry:
+"Prøv igen",
+error_crawlingfailed_title:
+"Det ble et problem med å gjennomføre din bestilling.",
+error_crawling_unreachable:
+"Varen <strong>{0}</strong> er ikke tilgjengelig <strong>{1}</strong>. Se om ditt produkt URL er tilgjengelig.",
+error_crawling_product_not_found:
+"varen <strong>{0}</strong> ble ikke funnet <strong>{1}</strong>.",
+error_crawling_price_not_found:
+"Varen <strong>{0}</strong> har ikke fått spesifert en pris <strong>{1}</strong>, spesifisere prisen med data-item-price.",
+error_crawling_price_doesnot_match:
+"Varens <strong>{0}</strong> pris <strong>{3}</strong> er <strong>{2}</strong> men burde være <strong>{1}</strong>.",
+error_crawlingfailed_title_test:
+"Det oppsto en feil  din ordre. Hjemmesiden er pt. i test tilstand, og du er derfor ikke blevet opkrævet beløbet.",
+order_completedon:
+"Ordren er bekreftet",
+payment_method_status:
+"Betalingsmåte status",
+payment_method_status_approved:
+"Godkjent",
+order_reference_number:
+"Referansenummer",
+order_transaction_amount:
+"Transaksjonsbeløp",
+order_invoice_number:
+"Fakturanummer",
+order_authorization_code:
+"Autorisasjonskode",
+cart_plans_interval:
+"Intervall",
+cart_plans_interval_count:
+"Teller",
+subscription_plan_interval:
+"Planen intervall",
+subscription_plan_interval_count:
+"Planen intervall teller",
+plan_amount_per_day:
+"{0} / dag",
+plan_amount_per_week:
+"{0} / uke",
+plan_amount_per_month:
+"{0} / måned",
+plan_amount_per_year:
+"{0} / år",
+plan_amount_per_day_plural:
+"{0} / {1} dager",
+plan_amount_per_week_plural:
+"{0} / {1} uker",
+plan_amount_per_month_plural:
+"{0} / {1} neder",
+plan_amount_per_year_plural:
+"{0} / {1} år"
+});


### PR DESCRIPTION
with correct notation, taking into account Norways two written languages.

Norwegian is split into two written languages, Bokmål and Nynorsk. As such bokmål pages use either the language attribute "no" or "nb-NO". Nynorsk uses "nn-NO".