### PR TITLE
Keep up-do-date Canadian French and French localisations

### DIFF
--- a/locales/en.js
+++ b/locales/en.js
@@ -438,7 +438,7 @@ subscription_cancel_button:
 subscription_pause_button:
 "Pause",
 subscription_cancel_confirmation:
-"Are you sure you want to cancel your subscription ?",
+"Are you sure you want to cancel your subscription?",
 subscription_cancel_success:
 "Your subscription has been cancelled successfully.",
 subscription_cancelled_notice:
@@ -517,9 +517,9 @@ something_went_wrong_while_fetching_rates:
 "We have not been able to find any shipping methods for the address you specified. Contact us directly if you need help regarding this.",
 error_must_select_shipping_rate:
 "You must select shipping method to continue.",
-back_to_orders: 
+back_to_orders:
 "Back to orders",
-manage_subscriptions: 
+manage_subscriptions:
 "Manage subscriptions",
 back_to_subscriptions_list:
 "Back to subscriptions list",
@@ -529,8 +529,6 @@ discount_remove_confirmation_msg:
 "Are you sure you want to remove the discount?",
 notifications_item_not_modified_due_to_min_quantity:
 "Sorry, you need to order at least {0} of this product.",
-subscription_pause_button:
-"Pause",
 subscription_resume_buttom:
 "Resume",
 subscription_summary:

--- a/locales/fr-CA.js
+++ b/locales/fr-CA.js
@@ -11,10 +11,10 @@ checkout:
 "Passer au paiement",
 close:
 "Fermer",
-name:
-"Nom",
 first_name:
 "Prénom",
+name:
+"Nom",
 last_name:
 "Nom",
 company_name:
@@ -57,8 +57,6 @@ apply_promo_code:
 "Appliquer un code promo",
 my_cart:
 "Mon panier",
-continue_shopping:
-"Continuer à magasiner",
 my_cart_content:
 "Contenu de mon panier",
 shipping_method:
@@ -69,8 +67,16 @@ confirm_order:
 "Confirmation de l'achat",
 bill_me_later:
 "Payer plus tard",
+bill_me_later_action:
+"Payer plus tard",
 bill_me_later_explanation:
 "Une facture vous sera envoyée par courriel.",
+pay_via_mollie:
+"Choisir une méthode de paiement",
+pay_now_via_mollie:
+"Payer maintenant",
+pay_via_mollie_explanation:
+"Vous allez être redirigé vers une liste d'options de paiement.",
 promo_code_applied_successfully:
 "Votre code promo a été appliqué avec succès.",
 promo_code_is_invalid:
@@ -191,6 +197,8 @@ payment_method_card_exp_year:
 "Année d'expiration",
 payment_method_cvc_infos:
 "Le CVC est le code de sécurité à 3 chiffres habituellement en arrière de votre carte à droite de la signature.",
+payment_status:
+"Status du paiement",
 create_an_account:
 "Créer un compte",
 why_create_account:
@@ -213,6 +221,8 @@ account_created_successfully_message:
 "Votre compte a été créé avec succès, merci beaucoup.",
 errors_required:
 "Ce champ est requis",
+errors_passwords_dont_match:
+"Les deux mots de passe doivent concorder",
 errors_email_must_be_unique:
 "Un usager avec le même courriel existe déjà",
 errors_both_password_must_match:
@@ -230,9 +240,11 @@ errors_invalid_authentication_infos:
 error_payment_items_empty:
 "Il semble que votre commande est invalide, veuillez rafraîchir la page. Votre carte de crédit n'a pas été chargée.",
 error_payment_items_are_invalid:
-"Nous n'avons pas pu complété votre commande. Il semble qu'un article dans votre panier a un prix invalide.",
+"Nous n'avons pas pu compléter votre commande. Il semble qu'un article dans votre panier a un prix invalide.",
 error_crawling_failed:
-"Nous n'avons pas pu validé votre commande. Votre carte de crédit n'a pas été chargée. Veuillez réessayer dans quelques instants.",
+"Nous n'avons pas pu valider votre commande. Votre carte de crédit n'a pas été chargée. Veuillez réessayer dans quelques instants.",
+error_discounts_have_expired:
+"Malheureusement l'un des codes promos que vous avez utilisé a expiré pendant le processus de commande. S'il vous plait, vérifiez la commande ci-dessous puis rééssayez.",
 powered_by:
 "Propulsé et sécurisé par",
 promocode_rate_format:
@@ -255,6 +267,8 @@ generic_error_title:
 "Oops, une erreur est survenue.",
 promocode_deleted_at_checkout:
 "Le code promo que vous avez utilisé a atteint son nombre d'utilisation maximum durant votre paiement. Nous sommes désolés de cet inconvénient.",
+continue_shopping:
+"Continuer à magasiner",
 payment_required_message:
 "Le panier d'achat de ce site a été désactivé. Si vous êtes le propriétaire du site, veuillez vous connecter à votre compte Snipcart afin de résoudre le problème.",
 payment_require_title:
@@ -278,7 +292,7 @@ error_crawlingfailed_title:
 error_crawling_unreachable:
 "Le produit <strong>{0}</strong> n'est pas accessible à l'adresse <strong>{1}</strong>. Veuillez vous assurer que cette URL est accessible.",
 error_crawling_product_not_found:
-"Nous n'avons pas pu trouvé le produit <strong>{0}</strong> à l'adresse <strong>{1}</strong>",
+"Nous n'avons pas pu trouver le produit <strong>{0}</strong> à l'adresse <strong>{1}</strong>",
 error_crawling_price_not_found:
 "Le prix du produit <strong>{0}</strong> n'est pas spécifié à l'adresse <strong>{1}</strong>, veuillez le spécifier avec data-item-price",
 error_crawling_price_doesnot_match:
@@ -343,6 +357,8 @@ order_total:
 "Total",
 orders_history:
 "Mes commandes",
+subscriptions_history_no_subscriptions:
+"Vous n'avez encore aucun abonnement.",
 orders_history_no_orders:
 "Vous n'avez aucune commande.",
 orders_fetching_orders:
@@ -419,6 +435,8 @@ plan_days_of_trial:
 "{0} jour(s) d'essai",
 subscription_cancel_button:
 "Annuler cet abonnement",
+subscription_pause_button:
+"Suspendre cet abonnement",
 subscription_cancel_confirmation:
 "Êtes-vous sûr de vouloir annuler cet abonnement ?",
 subscription_cancel_success:
@@ -447,6 +465,42 @@ item_invalid_must_remove:
 "Ce produit ne semble plus être disponible. Il peut s'agir d'un problème de configuration. En continuant, cet item sera enlevé de votre panier.",
 accept_cart_changes:
 "Accepter les changement et continuer",
+payment_failed_text:
+"Désolé, nous n'avons pas pu procéder à votre paiement. Vous pouvez continuer vos achats ou essayer de nouveau en utilisant les boutons ci-dessous.",
+payment_method_willbepaidlater:
+"Différée",
+payment_method_paypal:
+"Paypal",
+payment_method_none:
+"Aucune",
+payment_method_sofort:
+"Sofort",
+payment_method_ideal:
+"Ideal",
+payment_method_mistercash:
+"Mister Cash",
+payment_method_banktransfer:
+"Bank transfer",
+payment_method_directdebit:
+"Direct debit",
+payment_method_belfius:
+"Belfius",
+payment_method_bitcoin:
+"Bitcoin",
+payment_method_podiumcadeaukaart:
+"Podium Cadeau Kaart",
+payment_method_paysafecard:
+"PaySafe card",
+payment_method_bancontact:
+"Bancontact",
+payment_method_creditcard:
+"Carte de crédit",
+error_item_stock_exceeded:
+"Désolé ! Votre demande dépasse le stock disponible pour cet élément.",
+error_item_out_of_stock_text:
+"Désolé ! Il semble que le produit n'est plus disponible. Nous vous suggérons de vérifier de nouveau ultérieurement.",
+item_out_of_stock_with_variant:
+"Désolé ! Il semble que cette déclinaison de produit n'est plus disponible. S'il vous plait, sélectionnez une nouvelle déclinaison ou cet article va être retiré de votre panier.",
 order_status_processed:
 "Traitée",
 order_status_disputed:
@@ -459,7 +513,34 @@ order_status_pending:
 "En attente",
 order_status_cancelled:
 "Annulée",
-"back_to_orders": "Retour à la liste des commandes",
+something_went_wrong_while_fetching_rates:
+"Nous n'avons pas été capable de trouver de méthode d'envoi pour l'adresse que vous avez spécifiée. Contactez-nous directement si vous avez besoin d'aide.",
+error_must_select_shipping_rate:
+"Vous devez sélectionner une méthode d'envoi pour continuer.",
+back_to_orders:
+"Retour à la liste des commandes",
+manage_subscriptions:
+"Gérer les abonnements",
+back_to_subscriptions_list:
+"Retour à la liste des abonnements",
+back_to_subscription_details:
+"Retour au détails de l'abonnement",
 discount_remove_confirmation_msg:
-"Êtes-vous certain de vouloir retirer le code promo?"
+"Êtes-vous certain de vouloir retirer le code promo ?",
+notifications_item_not_modified_due_to_min_quantity:
+"Désolé, vous devez commander au minimum {0} de ces produits.",
+subscription_resume_buttom:
+"Reprendre",
+subscription_summary:
+"Sommaire",
+subscription_notifications_paused:
+"Cet abonnement est actuellement en pause, vous pouvez le reprendre en cliquant sur le bouton Reprendre.",
+subscription_notifications_pause_confirm:
+"Êtes-vous sûr de vouloir suspendre votre abonnement ?",
+subscription_notifications_resume_confirm:
+"Êtes-vous sûr de vouloir reprendre votre abonnement ?",
+subscription_status_canceled:
+"Annulée",
+subscription_status_paused:
+"Suspendue"
 });

--- a/locales/fr-CA.js
+++ b/locales/fr-CA.js
@@ -192,7 +192,7 @@ payment_method_card_number:
 payment_method_card_cvc:
 "CVC",
 payment_method_card_exp_month:
-"Mois / Année d'expiration",
+"Mois d'expiration",
 payment_method_card_exp_year:
 "Année d'expiration",
 payment_method_cvc_infos:

--- a/locales/fr-FR.js
+++ b/locales/fr-FR.js
@@ -1,391 +1,546 @@
 ﻿Snipcart.execute('registerLocale', 'fr-FR', {
-    yes:
-    "Oui",
-    no:
-    "Non",
-    print:
-    "Imprimer",
-    download_as_pdf:
-    "Télécharger le PDF",
-    checkout:
-    "Passer au paiement",
-    close:
-    "Fermer",
-    name:
-    "Nom",
-    company_name:
-    "Nom de la société",
-    share_by_email:
-    "Partager par courriel",
-    email:
-    "Courriel",
-    password:
-    "Mot de passe",
-    confirm_password:
-    "Confirmer le mot de passe",
-    ok:
-    "OK",
-    send:
-    "Envoyer",
-    address_1:
-    "Adresse",
-    address_2:
-    "Adresse 2",
-    city:
-    "Ville",
-    postal_code:
-    "Code postal",
-    phone:
-    "Téléphone",
-    previous:
-    "Étape précédente",
-    next:
-    "Étape suivante",
-    finalize:
-    "Terminer la commande",
-    country:
-    "Pays",
-    subtotal:
-    "Sous-total",
-    rebate:
-    "Rabais",
-    apply_promo_code:
-    "Appliquer un code promo",
-    my_cart:
-    "Mon panier",
-    my_cart_content:
-    "Contenu de mon panier",
-    shipping_method:
-    "Mode de livraison",
-    payment_method:
-    "Mode de paiement",
-    confirm_order:
-    "Confirmation de l'achat",
-    bill_me_later:
-    "Payer plus tard",
-    bill_me_later_explanation:
-    "Une facture vous sera envoyée par courriel.",
-    promo_code_applied_successfully:
-    "Votre code promo a été appliqué avec succès.",
-    promo_code_is_invalid:
-    "Le code promo est invalide.",
-    promo_code_is_expired:
-    "Le code promo est expiré.",
-    promo_code_code:
-    "Codes promos",
-    promo_code_rate_on_order:
-    "de rabais sur la commande",
-    promo_code_alternate_price:
-    "prix spécial sur certains articles",
-    total:
-    "Total",
-    total_paid:
-    "Total payé",
-    province_state:
-    "Province / État",
-    billing_address:
-    "Adresse de facturation",
-    shipping_address:
-    "Adresse de livraison",
-    payment_informations:
-    "Informations de paiement",
-    payment_informations_bill_me_later:
-    "Je paierai plus tard",
-    payment_informations_paypalexpress:
-    "Paiement via Paypal",
-    credit_card_type_mastercard:
-    "Mastercard",
-    credit_card_type_visa:
-    "Visa",
-    credit_card_type_amex:
-    "American Express",
-    months_january:
-    "Janvier",
-    months_february:
-    "Février",
-    months_march:
-    "Mars",
-    months_april:
-    "Avril",
-    months_may:
-    "Mai",
-    months_june:
-    "Juin",
-    months_july:
-    "Juillet",
-    months_august:
-    "Août",
-    months_september:
-    "Septembre",
-    months_october:
-    "Octobre",
-    months_november:
-    "Novembre",
-    months_december:
-    "Décembre",
-    cart_items_table_item:
-    "Article",
-    cart_items_table_description:
-    "Description",
-    cart_items_table_quantity:
-    "Quantité",
-    cart_items_table_unit_price:
-    "Prix unitaire",
-    cart_items_table_total_price:
-    "Prix total",
-    cart_empty_text:
-    "Votre panier est actuellement vide. Sélectionnez des produits afin de procéder au paiement.",
-    new_account_form_create_new_account:
-    "Créer un nouveau compte",
-    new_account_form_create_new_account_action:
-    "Créer",
-    login_form_having_an_account:
-    "Vous avez un compte ?",
-    login_form_login_action:
-    "Connexion",
-    login_title:
-    "Connexion",
-    login_form_forgot_password_action:
-    "J'ai oublié mon mot de passe",
-    forgot_password_forgot_your_password:
-    "Oublié votre mot de passe ?",
-    forgot_password_please_enter_email:
-    "Veuillez saisir votre courriel, nous vous enverrons un courriel contenant un lien unique qui vous permettra de réinitilaiser votre mot de passe",
-    forgot_password_success_email_sent:
-    "Le courriel a été envoyé",
-    forgot_password_email_sent_message:
-    "Un courriel vous a été envoyé avec les instructions pour réinitialiser votre mot de passe. Veuillez aller consulter celui-ci.",
-    login_checkout_as_guest:
-    "Payer sans compte",
-    login_checkout_as_guest_notice:
-    "À la fin du processus de paiement, nous vous offririons la possiblité de vous créer un compte avec les informations que vous aurez saisi durant le processus de paiement.",
-    shipping_address_same_as_billing:
-    "Utiliser cette adresse pour la livraison",
-    shipping_method_method_name:
-    "Mode de livraison",
-    shipping_method_shipping_price:
-    "Prix de la livraison",
-    shipping_method_failure_message:
-    "Nous n'avons pas été en mesure de trouver un mode de livraison. Veuillez vous assurer que votre adresse de livraison est correcte et essayez à nouveau.",
-    shipping_method_failure_click_here_to_edit:
-    "Cliquez ici pour modifier votre adresse de livraison",
-    payment_method_card_holder:
-    "Nom sur la carte",
-    payment_method_card_type:
-    "Type de la carte",
-    payment_method_card_number:
-    "Numéro de la carte",
-    payment_method_card_cvc:
-    "CVC",
-    payment_method_card_exp_month:
-    "Mois / Année d'expiration",
-    payment_method_card_exp_year:
-    "Année d'expiration",
-    payment_method_cvc_infos:
-    "Le CVC est le code de sécurité à 3 chiffres habituellement à l'arrière de votre carte à droite de la signature.",
-    create_an_account:
-    "Créer un compte",
-    why_create_account:
-    "Pour commander plus rapidement la prochaine fois, entrez un mot de passe pour créer un compte.",
-    reset_password:
-    "Réinitialiser mon mot de passe",
-    reset_password_success:
-    "Votre mot de passe a été réinitialisé",
-    reset_password_changed:
-    "Votre mot de passe a été mis à jour.",
-    reset_password_click_here_to_login:
-    "Cliquez ici pour vous connecter",
-    thankyou_message:
-    "Merci pour votre commande ! Votre facture vous a été envoyée par courriel.",
-    thankyou_submessage:
-    "Vous recevrez un courriel de confirmation bientôt",
-    account_created_successfully:
-    "Compte créé avec succès",
-    account_created_successfully_message:
-    "Votre compte a été créé avec succès, merci beaucoup.",
-    errors_required:
-    "Ce champ est requis",
-    errors_email_must_be_unique:
-    "Un usager avec le même courriel existe déjà",
-    errors_both_password_must_match:
-    "Les deux mots de passe doivent être identiques",
-    errors_email_must_be_valid:
-    "Le courriel doit être valide",
-    errors_email_does_not_match_any_existing_user:
-    "Aucun usager n'existe avec ce courriel.",
-    errors_email_does_not_match_reset_password_request:
-    "La demande de réinitialisation de mot de passe ne concorde pas avec le courriel.",
-    errors_reset_password_token_expired:
-    "La demande de réinitialisation de mot de passe est expirée.",
-    errors_invalid_authentication_infos:
-    "Les informations de connexion sont invalides.",
-    error_payment_items_empty:
-    "Il semble que votre commande est invalide, veuillez rafraîchir la page. Votre carte de crédit n'a pas été chargée.",
-    error_payment_items_are_invalid:
-    "Nous n'avons pas pu compléter votre commande. Il semble qu'un article dans votre panier a un prix invalide.",
-    error_crawling_failed:
-    "Nous n'avons pas pu valider votre commande. Votre carte de crédit n'a pas été débitée. Veuillez réessayer dans quelques instants.",
-    powered_by:
-    "Propulsé et sécurisé par",
-    promocode_rate_format:
-    "{0}% de rabais sur votre commande",
-    promocode_amount_format:
-    "{0} de rabais sur votre commande",
-    shipping_method_business_days:
-    "{0} jours ouvrables",
-    shipping_method_business_day:
-    "{0} jour ouvrable",
-    shipping_method_delivery_time:
-    "D'ici {0}",
-    welcome:
-    "Bienvenue",
-    back:
-    "Retour",
-    order_infos:
-    "Infos sur la commande",
-    generic_error_title:
-    "Oups, une erreur est survenue.",
-    promocode_deleted_at_checkout:
-    "Le code promo que vous avez utilisé a atteint son nombre d'utilisation maximum durant votre paiement. Nous sommes désolés de cet inconvénient.",
-    continue_shopping:
-    "Continuer les achats",
-    payment_required_message:
-    "Le panier d'achat de ce site a été désactivé. Si vous êtes le propriétaire du site, veuillez vous connecter à votre compte Snipcart afin de résoudre le problème.",
-    payment_require_title:
-    "Le panier d'achat est désactivé.",
-    configuration_problem:
-    "Problème de configuration",
-    additionnal_information:
-    "Vous pouvez saisir un message ci-dessous si vous voulez donner des commentaires ou plus d'information sur le problème.",
-    send_error:
-    "Envoyer ce message au créateur du site",
-    message_sent:
-    "Message envoyé, merci",
-    paypalexpress_loading:
-    "Vous serez redirigé vers Paypal pour effectuer le paiement dans quelques instants.",
-    paypalexpress_cancelled:
-    "Vous avez annulé la transaction, cliquez sur le bouton ci-dessous afin de la compléter, ou vous pouvez continuer vos achats.",
-    retry:
-    "Réessayer",
-    error_crawlingfailed_title:
-    "Une erreur est survenue lors de la validation de votre commande, ne vous inquiétez pas, vous n'avez pas été débité.",
-    error_crawling_unreachable:
-    "Le produit <strong>{0}</strong> n'est pas accessible à l'adresse <strong>{1}</strong>. Veuillez vous assurer que cette URL est accessible.",
-    error_crawling_product_not_found:
-    "Nous n'avons pas pu trouver le produit <strong>{0}</strong> à l'adresse <strong>{1}</strong>",
-    error_crawling_price_not_found:
-    "Le prix du produit <strong>{0}</strong> n'est pas spécifié à l'adresse <strong>{1}</strong>, veuillez le spécifier avec data-item-price",
-    error_crawling_price_doesnot_match:
-    "Le prix du produit <strong>{0}</strong> à l'adresse <strong>{3}</strong> est <strong>{2}</strong> mais devrait être <strong>{1}</strong>",
-    error_crawlingfailed_title_test:
-    "Une erreur est survenue lors de la validation de votre commande, ne vous inquiétez pas, vous n'avez pas été débité. Ce site est actuellement en mode Test.",
-    order_completedon:
-    "Date de la commande",
-    payment_method_status:
-    "Statut de la transaction",
-    payment_method_status_approved:
-    "Approuvée",
-    order_reference_number:
-    "Numéro de référence",
-    order_transaction_amount:
-    "Montant de la transaction",
-    order_invoice_number:
-    "Numéro de la facture",
-    order_authorization_code:
-    "Code d'autorisation",
-    item_is_being_added:
-    "Ajout de l'item au panier...",
-    order_completing_payment:
-    "Paiement en cours...",
-    calculating_shipping_fees:
-    "Calcul des frais de livraison...",
-    saving:
-    "Sauvegarde...",
-    loading:
-    "Chargement...",
-    free_shipping:
-    "Livraison gratuite",
-    cart_plans_name:
-    "Plan",
-    cart_plans_interval:
-    "Intervalle",
-    cart_plans_interval_count:
-    "Fréquence",
-    cart_plans_quantity:
-    "Quantité",
-    cart_plans_amount:
-    "Montant",
-    cart_plans_total:
-    "Total",
-    payable_now:
-    "Payable maintenant",
-    upcoming_payment_for:
-    "Abonnement",
-    upcoming_payment_date:
-    "Date",
-    upcoming_payment_amount:
-    "Total",
-    upcoming_payment_subtotal:
-    "Sous-total",
-    upcoming_payments:
-    "Prochains paiements",
-    order_date:
-    "Date",
-    order_status:
-    "Statut",
-    order_total:
-    "Total",
-    orders_history:
-    "Mes commandes",
-    notifications_item_not_added_due_to_max_quantity:
-    "Le produit n'a pas pu être ajouté, vous avez déjà le nombre maximal dans votre panier.",
-    error_impossible_to_calculate_taxes:
-    "Impossible de calculer la taxe pour cette commande, cela peut être causé par une adresse invalide, svp assurez-vous d'avoir entré une adresse et un code postal valide.",
-    have_a_promocode_question:
-    "Code promo?",
-    order_totals_computing:
-    "Calcul des taxes...",
-    order_validation_failed:
-    "Nous n'avons pas réussi à valider votre commande. Veuillez vérifier votre panier et réessayer de nouveau.",
-    item_invalid_must_remove:
-    "Ce produit ne semble plus être disponible. Il peut s'agir d'un problème de configuration. En continuant, cet item sera enlevé de votre panier.",
-    accept_cart_changes:
-    "Accepter les changement et continuer",
-    order_status_processed:
-    "Traitée",
-    order_status_disputed:
-    "Disputée",
-    order_status_shipped:
-    "Expédiée",
-    order_status_delivered:
-    "Reçue",
-    order_status_pending:
-    "En attente",
-    order_status_cancelled:
-    "Annulée",
-    plan_amount_per_day:
-    "{0} / jour",
-    plan_amount_per_week:
-    "{0} / semaine",
-    plan_amount_per_month:
-    "{0} / mois",
-    plan_amount_per_year:
-    "{0} / année",
-    plan_amount_per_day_plural:
-    "{0} / {1} jours",
-    plan_amount_per_week_plural:
-    "{0} / {1} semaines",
-    plan_amount_per_month_plural:
-    "{0} / {1} mois",
-    plan_amount_per_year_plural:
-    "{0} / {1} ans",
-    plan_days_of_trial:
-    "{0} jour(s) d'essai",
-    "back_to_orders": "Retour à la liste des commandes",
-    subscription_plan_interval:
-    "Intervalle de plan",
-    subscription_plan_interval_count:
-    "Fréquece d'intervalle de plan",
-    discount_remove_confirmation_msg:
-    "Êtes-vous certain de vouloir retirer le code promo?"
+yes:
+"Oui",
+no:
+"Non",
+print:
+"Imprimer",
+download_as_pdf:
+"Télécharger le PDF",
+checkout:
+"Passer au paiement",
+close:
+"Fermer",
+first_name:
+"Prénom",
+name:
+"Nom",
+last_name:
+"Nom",
+company_name:
+"Nom de la société",
+share_by_email:
+"Partager par courriel",
+email:
+"Courriel",
+password:
+"Mot de passe",
+confirm_password:
+"Confirmer le mot de passe",
+ok:
+"OK",
+send:
+"Envoyer",
+address_1:
+"Adresse",
+address_2:
+"Complément d'adresse",
+city:
+"Ville",
+postal_code:
+"Code postal",
+phone:
+"Téléphone",
+previous:
+"Étape précédente",
+next:
+"Étape suivante",
+finalize:
+"Terminer la commande",
+country:
+"Pays",
+subtotal:
+"Sous-total",
+rebate:
+"Rabais",
+apply_promo_code:
+"Appliquer un code promo",
+my_cart:
+"Mon panier",
+my_cart_content:
+"Contenu de mon panier",
+shipping_method:
+"Méthode de livraison",
+payment_method:
+"Méthode de paiement",
+confirm_order:
+"Confirmation de l'achat",
+bill_me_later:
+"Payer plus tard",
+bill_me_later_action:
+"Payer plus tard",
+bill_me_later_explanation:
+"Une facture vous sera envoyée par courriel.",
+pay_via_mollie:
+"Choisir une méthode de paiement",
+pay_now_via_mollie:
+"Payer maintenant",
+pay_via_mollie_explanation:
+"Vous allez être redirigé vers une liste d'options de paiement.",
+promo_code_applied_successfully:
+"Votre code promo a été appliqué avec succès.",
+promo_code_is_invalid:
+"Le code promo est invalide.",
+promo_code_is_expired:
+"Le code promo est expiré.",
+promo_code_code:
+"Un code promo ?",
+promo_code_rate_on_order:
+"de rabais sur la commande",
+promo_code_alternate_price:
+"prix spécial sur certains articles",
+total:
+"Total",
+total_paid:
+"Total payé",
+province_state:
+"Département / Province / État",
+billing_address:
+"Adresse de facturation",
+shipping_address:
+"Adresse de livraison",
+payment_informations:
+"Informations de paiement",
+payment_informations_bill_me_later:
+"Je paierai plus tard",
+payment_informations_no_payment_required:
+"Aucun paiement requis",
+payment_informations_paypalexpress:
+"Paiement via Paypal",
+credit_card_type_mastercard:
+"Mastercard",
+credit_card_type_visa:
+"Visa",
+credit_card_type_amex:
+"American Express",
+months_january:
+"Janvier",
+months_february:
+"Février",
+months_march:
+"Mars",
+months_april:
+"Avril",
+months_may:
+"Mai",
+months_june:
+"Juin",
+months_july:
+"Juillet",
+months_august:
+"Août",
+months_september:
+"Septembre",
+months_october:
+"Octobre",
+months_november:
+"Novembre",
+months_december:
+"Décembre",
+cart_items_table_item:
+"Article",
+cart_items_table_description:
+"Description",
+cart_items_table_quantity:
+"Quantité",
+cart_items_table_unit_price:
+"Prix unitaire",
+cart_items_table_total_price:
+"Prix total",
+cart_empty_text:
+"Votre panier est actuellement vide. Sélectionnez des produits afin de procéder au paiement.",
+new_account_form_create_new_account:
+"Créer un nouveau compte",
+new_account_form_create_new_account_action:
+"Créer",
+login_form_having_an_account:
+"Vous avez un compte ?",
+login_form_login_action:
+"Connexion",
+login_title:
+"Connexion",
+login_form_forgot_password_action:
+"J'ai oublié mon mot de passe",
+forgot_password_forgot_your_password:
+"Oublié votre mot de passe ?",
+forgot_password_please_enter_email:
+"Veuillez saisir votre courriel, nous vous enverrons un courriel contenant un lien unique qui vous permettra de réinitilaiser votre mot de passe",
+forgot_password_success_email_sent:
+"Le courriel a été envoyé",
+forgot_password_email_sent_message:
+"Un courriel vous a été envoyé avec les instructions pour réinitialiser votre mot de passe. Veuillez consulter celui-ci et suivre les étapes.",
+login_checkout_as_guest:
+"Payer sans compte",
+login_checkout_as_guest_notice:
+"À la fin du processus de paiement, nous vous offririons la possiblité de vous créer un compte avec les informations que vous aurez saisi durant le processus de paiement.",
+shipping_address_same_as_billing:
+"Utiliser cette adresse pour la livraison",
+shipping_method_method_name:
+"Méthode de livraison",
+shipping_method_shipping_price:
+"Prix de la livraison",
+shipping_method_failure_message:
+"Nous n'avons pas été en mesure de trouver une méthode de livraison. Veuillez vous assurer que votre adresse de livraison est correcte et essayez à nouveau.",
+shipping_method_failure_click_here_to_edit:
+"Cliquez ici pour modifier votre adresse de livraison",
+payment_method_card_holder:
+"Nom sur la carte",
+payment_method_card_type:
+"Type de la carte",
+payment_method_card_number:
+"Numéro de la carte",
+payment_method_card_cvc:
+"CVC",
+payment_method_card_exp_month:
+"Mois / Année d'expiration",
+payment_method_card_exp_year:
+"Année d'expiration",
+payment_method_cvc_infos:
+"Le CVC est le code de sécurité à 3 chiffres habituellement à l'arrière de votre carte à droite de la signature.",
+payment_status:
+"Status du paiement",
+create_an_account:
+"Créer un compte",
+why_create_account:
+"Pour commander plus rapidement la prochaine fois, entrez un mot de passe pour créer un compte.",
+reset_password:
+"Réinitialiser mon mot de passe",
+reset_password_success:
+"Votre mot de passe a été réinitialisé",
+reset_password_changed:
+"Votre mot de passe a été mis à jour.",
+reset_password_click_here_to_login:
+"Cliquez ici pour vous connecter",
+thankyou_message:
+"Merci pour votre commande ! Votre facture vous a été envoyée par courriel.",
+thankyou_submessage:
+"Vous recevrez un courriel de confirmation bientôt",
+account_created_successfully:
+"Compte créé avec succès",
+account_created_successfully_message:
+"Votre compte a été créé avec succès, merci beaucoup.",
+errors_required:
+"Ce champ est requis",
+errors_passwords_dont_match:
+"Les deux mots de passe doivent concorder",
+errors_email_must_be_unique:
+"Un utilisateur avec le même courriel existe déjà",
+errors_both_password_must_match:
+"Les deux mots de passe doivent être identiques",
+errors_email_must_be_valid:
+"Le courriel doit être valide",
+errors_email_does_not_match_any_existing_user:
+"Aucun utilisateur n'existe avec ce courriel.",
+errors_email_does_not_match_reset_password_request:
+"La demande de réinitialisation de mot de passe ne concorde pas avec le courriel.",
+errors_reset_password_token_expired:
+"La demande de réinitialisation de mot de passe est expirée.",
+errors_invalid_authentication_infos:
+"Les informations de connexion sont invalides.",
+error_payment_items_empty:
+"Il semble que votre commande est invalide, veuillez rafraîchir la page. Votre carte de crédit n'a pas été débitée.",
+error_payment_items_are_invalid:
+"Nous n'avons pas pu compléter votre commande. Il semble qu'un article dans votre panier ait un prix invalide.",
+error_crawling_failed:
+"Nous n'avons pas pu valider votre commande. Votre carte de crédit n'a pas été débitée. Veuillez réessayer dans quelques instants.",
+error_discounts_have_expired:
+"Malheureusement l'un des codes promos que vous avez utilisé a expiré pendant le processus de commande. S'il vous plait, vérifiez la commande ci-dessous puis rééssayez.",
+powered_by:
+"Propulsé et sécurisé par",
+promocode_rate_format:
+"{0}% de rabais sur votre commande",
+promocode_amount_format:
+"{0} de rabais sur votre commande",
+shipping_method_business_days:
+"{0} jours ouvrables",
+shipping_method_business_day:
+"{0} jour ouvrable",
+shipping_method_delivery_time:
+"D'ici {0}",
+welcome:
+"Bienvenue",
+back:
+"Retour",
+order_infos:
+"Infos sur la commande",
+generic_error_title:
+"Oups, une erreur est survenue.",
+promocode_deleted_at_checkout:
+"Le code promo que vous avez utilisé a atteint son nombre d'utilisation maximum durant votre paiement. Nous sommes désolés de cet inconvénient.",
+continue_shopping:
+"Continuer les achats",
+payment_required_message:
+"Le panier d'achat de ce site a été désactivé. Si vous êtes le propriétaire du site, veuillez vous connecter à votre compte Snipcart afin de résoudre le problème.",
+payment_require_title:
+"Le panier d'achat est désactivé.",
+configuration_problem:
+"Problème de configuration",
+additionnal_information:
+"Vous pouvez saisir un message ci-dessous si vous voulez donner des commentaires ou plus d'information sur le problème.",
+send_error:
+"Envoyer ce message au propriétaire du site",
+message_sent:
+"Message envoyé, merci",
+paypalexpress_loading:
+"Vous serez redirigé vers Paypal pour effectuer le paiement dans quelques instants...",
+paypalexpress_cancelled:
+"Vous avez annulé la transaction, cliquez sur le bouton ci-dessous afin de la compléter, ou vous pouvez continuer vos achats.",
+retry:
+"Réessayer",
+error_crawlingfailed_title:
+"Une erreur est survenue lors de la validation de votre commande, ne vous inquiétez pas, vous n'avez pas été débité.",
+error_crawling_unreachable:
+"Le produit <strong>{0}</strong> n'est pas accessible à l'adresse <strong>{1}</strong>. Veuillez vous assurer que cette URL est accessible.",
+error_crawling_product_not_found:
+"Nous n'avons pas pu trouver le produit <strong>{0}</strong> à l'adresse <strong>{1}</strong>",
+error_crawling_price_not_found:
+"Le prix du produit <strong>{0}</strong> n'est pas spécifié à l'adresse <strong>{1}</strong>, veuillez le spécifier avec data-item-price",
+error_crawling_price_doesnot_match:
+"Le prix du produit <strong>{0}</strong> à l'adresse <strong>{3}</strong> est <strong>{2}</strong> mais devrait être <strong>{1}</strong>",
+error_crawlingfailed_title_test:
+"Une erreur est survenue lors de la validation de votre commande, ne vous inquiétez pas, vous n'avez pas été débité. Ce site est actuellement en mode Test.",
+order_completedon:
+"Date de la commande",
+payment_method_status:
+"Statut de la transaction",
+payment_method_status_approved:
+"Approuvée",
+order_reference_number:
+"Numéro de référence",
+order_transaction_amount:
+"Montant de la transaction",
+order_invoice_number:
+"Numéro de la facture",
+order_authorization_code:
+"Code d'autorisation",
+item_is_being_added:
+"Ajout de l'item au panier...",
+order_completing_payment:
+"Paiement en cours...",
+calculating_shipping_fees:
+"Calcul des frais de livraison...",
+saving:
+"Sauvegarde...",
+loading:
+"Chargement...",
+free_shipping:
+"Livraison gratuite",
+cart_plans_name:
+"Plan",
+cart_plans_interval:
+"Intervalle",
+cart_plans_interval_count:
+"Fréquence",
+cart_plans_quantity:
+"Quantité",
+cart_plans_amount:
+"Montant",
+cart_plans_total:
+"Total",
+payable_now:
+"Payable maintenant",
+upcoming_payment_for:
+"Abonnement",
+upcoming_payment_date:
+"Date",
+upcoming_payment_amount:
+"Total",
+upcoming_payment_subtotal:
+"Sous-total",
+upcoming_payments:
+"Prochains paiements",
+order_date:
+"Date",
+order_status:
+"Statut",
+order_total:
+"Total",
+orders_history:
+"Mes commandes",
+subscriptions_history_no_subscriptions:
+"Vous n'avez encore aucun abonnement.",
+orders_history_no_orders:
+"Vous n'avez encore aucune commande.",
+orders_fetching_orders:
+"Chargement de vos commandes...",
+user_nav_orders:
+"Mes commandes",
+user_nav_subscriptions:
+"Mes abonnements",
+user_nav_cart:
+"Mon panier",
+subscriptions_history:
+"Mes abonnements",
+subscription_name:
+"Nom",
+subscription_amount:
+"Montant",
+subscription_quantity:
+"Quantité",
+subscription_total_amount:
+"Total",
+subscriptions_fetching_subscriptions:
+"Chargement des abonnements...",
+subscriptions_fetching_details:
+"Chargement des détails de l'abonnement...",
+subscription_no_invoices:
+"Cet abonnement n'a encore aucune factures.",
+subscription_plan_name:
+"Nom de plan",
+subscription_plan_interval:
+"Intervalle du plan",
+subscription_plan_interval_count:
+"Fréquence d'intervalle du plan",
+subscription_invoice_number:
+"No. de facture de l'abonnement",
+subscription_invoice_date:
+"Date",
+subscription_invoice_amount:
+"Montant",
+subscription_invoice_item:
+"Article",
+subscription_invoice_info:
+"Information de facture",
+subscription_invoice_details:
+"Détails de facture",
+subscription_invoice_fetching_details:
+"Chagement des détails de facture...",
+subscription_invoices_loading:
+"Chargement des factures d'abonnement...",
+subscription_invoices_list:
+"Historique des factures",
+item_out_of_stock:
+"Nous sommes désolé, cet article est maintenant épuisé.",
+click_here_to_remove_it:
+"Cliquez ici pour le retirer du pannier.",
+outofstock_notification:
+"Nous sommes désolé, certains des articles de votre panier sont devenus épuisés pendant le processus de commande. S'il vous plait, vérifiez votre commande. Ne vous inquiétez pas, vous n'avez pas été débité.",
+plan_amount_per_day:
+"{0} / jour",
+plan_amount_per_week:
+"{0} / semaine",
+plan_amount_per_month:
+"{0} / mois",
+plan_amount_per_year:
+"{0} / année",
+plan_amount_per_day_plural:
+"{0} / {1} jours",
+plan_amount_per_week_plural:
+"{0} / {1} semaines",
+plan_amount_per_month_plural:
+"{0} / {1} mois",
+plan_amount_per_year_plural:
+"{0} / {1} années",
+plan_days_of_trial:
+"{0} jours d'essai",
+subscription_cancel_button:
+"Annuler",
+subscription_pause_button:
+"Suspendre",
+subscription_cancel_confirmation:
+"Êtes-vous sûr de vouloir annuler cet abonnement ?",
+subscription_cancel_success:
+"Votre abonnement a été annulé avec succès.",
+subscription_cancelled_notice:
+"Cette abonnement n'est plus actif, il a été annulé en date du {0}.",
+subscription_cancelledon:
+"Annulé le",
+paypal_express_checkout_link:
+"Payer avec Paypal",
+paypal_express_checkout_title:
+"Payer avec PayPal",
+paypal_express_checkout_explanation:
+"Cliquez sur ce bouton si vous préferez payer directement via PayPal.",
+notifications_item_not_added_due_to_max_quantity:
+"Le produit n'a pas pu être ajouté, vous avez déjà le nombre maximal dans votre panier.",
+error_impossible_to_calculate_taxes:
+"Impossible de calculer la taxe pour cette commande, cela peut être causé par une adresse invalide, svp assurez-vous d'avoir entré une adresse et un code postal valide.",
+have_a_promocode_question:
+"Code promo ?",
+order_totals_computing:
+"Calcul des taxes...",
+order_validation_failed:
+"Nous n'avons pas réussi à valider votre commande. Veuillez vérifier votre panier et réessayer de nouveau.",
+item_invalid_must_remove:
+"Ce produit ne semble plus être disponible. Il peut s'agir d'un problème de configuration. En continuant, cet item sera enlevé de votre panier.",
+accept_cart_changes:
+"Accepter les changement et continuer",
+payment_failed_text:
+"Désolé, nous n'avons pas pu procéder à votre paiement. Vous pouvez continuer vos achats ou essayer de nouveau en utilisant les boutons ci-dessous.",
+payment_method_willbepaidlater:
+"Différée",
+payment_method_paypal:
+"Paypal",
+payment_method_none:
+"Aucune",
+payment_method_sofort:
+"Sofort",
+payment_method_ideal:
+"Ideal",
+payment_method_mistercash:
+"Mister Cash",
+payment_method_banktransfer:
+"Bank transfer",
+payment_method_directdebit:
+"Direct debit",
+payment_method_belfius:
+"Belfius",
+payment_method_bitcoin:
+"Bitcoin",
+payment_method_podiumcadeaukaart:
+"Podium Cadeau Kaart",
+payment_method_paysafecard:
+"PaySafe card",
+payment_method_bancontact:
+"Bancontact",
+payment_method_creditcard:
+"Carte de crédit",
+error_item_stock_exceeded:
+"Désolé ! Votre demande dépasse le stock disponible pour cet élément.",
+error_item_out_of_stock_text:
+"Désolé ! Il semble que le produit n'est plus disponible. Nous vous suggérons de vérifier de nouveau ultérieurement.",
+item_out_of_stock_with_variant:
+"Désolé ! Il semble que cette déclinaison de produit n'est plus disponible. S'il vous plait, sélectionnez une nouvelle déclinaison ou cet article va être retiré de votre pannier.",
+order_status_processed:
+"Traitée",
+order_status_disputed:
+"Contestée",
+order_status_shipped:
+"Expédiée",
+order_status_delivered:
+"Reçue",
+order_status_pending:
+"En attente",
+order_status_cancelled:
+"Annulée",
+something_went_wrong_while_fetching_rates:
+"Nous n'avons pas été capable de trouver de méthode d'envoi pour l'adresse que vous avez spécifiée. Contactez-nous directement si vous avez besoin d'aide.",
+error_must_select_shipping_rate:
+"Vous devez sélectionner une méthode d'envoi pour continuer.",
+back_to_orders:
+"Retour à la liste des commandes",
+manage_subscriptions:
+"Gérer les abonnements",
+back_to_subscriptions_list:
+"Retour à la liste des abonnements",
+back_to_subscription_details:
+"Retour au détails de l'abonnement",
+discount_remove_confirmation_msg:
+"Êtes-vous sûr de vouloir retirer ce code promo ?",
+notifications_item_not_modified_due_to_min_quantity:
+"Désolé, vous devez commander au minimum {0} de ces produits.",
+subscription_resume_buttom:
+"Reprendre",
+subscription_summary:
+"Sommaire",
+subscription_notifications_paused:
+"Cet abonnement est actuellement en pause, vous pouvez le reprendre en cliquant sur le bouton Reprendre.",
+subscription_notifications_pause_confirm:
+"Êtes-vous sûr de vouloir suspendre votre abonnement ?",
+subscription_notifications_resume_confirm:
+"Êtes-vous sûr de vouloir reprendre votre abonnement ?",
+subscription_status_canceled:
+"Annulée",
+subscription_status_paused:
+"Suspendue"
 });

--- a/locales/fr-FR.js
+++ b/locales/fr-FR.js
@@ -192,7 +192,7 @@ payment_method_card_number:
 payment_method_card_cvc:
 "CVC",
 payment_method_card_exp_month:
-"Mois / Année d'expiration",
+"Mois d'expiration",
 payment_method_card_exp_year:
 "Année d'expiration",
 payment_method_cvc_infos:


### PR DESCRIPTION
**In this PR:**
— Some `en.js` ponctuations ajustements
— Some `fr-FR.js` correction and up-to-date labelisation
— Rename `fr.js` into `fr-CA.js`
— Some `fr-CA.js` correction and up-to-date labelisation

_NOT in this PR:_
— I propose to rename all capitalize file into lowercase because this files are served by a server and by convention an URL is in lowercase. This should not infered with the fr-FR declaration into API. So a correct way should be:

Filename: `fr-fr.js`

HTML lang

```html
<html lang="fr-fr">
...
```

```js
Snipcart.execute('registerLocale', 'fr-FR', { /* or `Snipcart.execute('registerLocale', 'fr-fr', {` should be possible */
...
```

What are your thoughts about this?