### PR TITLE
Fix paypalexpress_loading message

### DIFF
--- a/locales/de.js
+++ b/locales/de.js
@@ -348,7 +348,7 @@ send_error:
 message_sent:
 "Die Nachricht wurde gesendet. Danke!",
 paypalexpress_loading:
-"Sie werden für die Zahlung zu PayPal weitergeleitet.",
+"Sie werden gleich weitergeleitet, bitte warten...",
 paypalexpress_cancelled:
 "Sie haben die Transaktion abgebrochen. Wenn Sie es nochmals versuchen wollen, klicken Sie auf den Knopf.",
 retry:


### PR DESCRIPTION
The previous translation included a reference to paypal, which is wrong. When using mollie as payment provider, the same string is used, so no reference to any payment provider should be included.